### PR TITLE
Update bounded_buffer_test.c

### DIFF
--- a/mandatory/src/bounded_buffer_test.c
+++ b/mandatory/src/bounded_buffer_test.c
@@ -4,6 +4,8 @@
  * History:
  *
  * 2020 - Original version by Karl Marklund <karl.marklund@it.uu.se>.
+ *
+ * 2021 - Updated behaviour for Ubuntu machines <bjorn.safsten.5186@student.uu.se>.
  */
 
 #include "bounded_buffer.h"
@@ -24,12 +26,19 @@ void success() {
 
 void init_test() {
   TEST_HEADER;
-
   buffer_t buffer;
+  
+  buffer.array = NULL;
+  buffer.mutex = NULL;
+  buffer.data = NULL;
+  buffer.empty = NULL;
+  
 
   buffer_init(&buffer, 10);
 
   assert(buffer.size == 10);
+  assert(buffer.in == 0);
+  assert(buffer.out == 0);
   assert(buffer.array != NULL);
   assert(buffer.mutex != NULL);
   assert(buffer.data  != NULL);


### PR DESCRIPTION
There seems to be a difference between how Ubuntu and Mac handles the creation of new struct variables. When running the old test on a Ubuntu machine (private and ThinClient) init_test() cannot fail due to new struct variables not being set to NULL upon declaration. This causes errors in the init_test() to look like they occur in destroy_test() which is confusing for the students. Setting all of the variables to NULL provides desired behavior on Ubuntu machines. Two additional assertions added to the init_test() to check that the "in" and "out" is set on init.