### PR TITLE
Fix first compilation Ubuntu

### DIFF
--- a/higher-grade/src/sthreads.c
+++ b/higher-grade/src/sthreads.c
@@ -59,6 +59,6 @@ void yield(){
 void  done(){
 }
 
-tid_t join() {
+tid_t join(tid_t thread) {
   return -1;
 }


### PR DESCRIPTION
Row 62 fails to compile in the first test run due to different numbers of arguments in header and c file